### PR TITLE
Add SearchManagerAddFilterTask for Search plugin autocomplete

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -48,6 +48,37 @@ use IdeHelperExtra\Authentication\Generator\Task\AuthServiceLoadIdentifierTask;
 ],
 ```
 
+#### Search.Manager::add()
+
+- SearchManagerAddFilterTask
+
+Provides autocomplete for filter types when using the [FriendsOfCake/search](https://github.com/FriendsOfCake/search) plugin.
+
+```php
+use IdeHelperExtra\Search\Generator\Task\SearchManagerAddFilterTask;
+
+...
+
+'IdeHelper' => [
+    'generatorTasks' => [
+        SearchManagerAddFilterTask::class => SearchManagerAddFilterTask::class,
+    ],
+],
+```
+
+Supports built-in filters (`Search.Value`, `Search.Like`, `Search.Boolean`, `Search.Callback`, `Search.Compare`, `Search.Exists`, `Search.Finder`) and discovers custom filters from `App\Model\Filter\` and plugins.
+
+To exclude built-in filters (since they have fluent method equivalents like `->callback()`):
+```php
+'IdeHelper' => [
+    'generatorTasks' => [
+        SearchManagerAddFilterTask::class => [
+            'includeDefaultFilters' => false,
+        ],
+    ],
+],
+```
+
 ### Add your own task
 
 The idea of this repository is to provide a way to collect useful tasks and addons where adding them into the main

--- a/src/Search/Generator/Task/SearchManagerAddFilterTask.php
+++ b/src/Search/Generator/Task/SearchManagerAddFilterTask.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IdeHelperExtra\Search\Generator\Task;
+
+use Cake\Core\Plugin;
+use IdeHelper\Filesystem\Folder;
+use IdeHelper\Generator\Directive\ExpectedArguments;
+use IdeHelper\Generator\Task\TaskInterface;
+use IdeHelper\Utility\App;
+use IdeHelper\Utility\AppPath;
+use IdeHelper\Utility\Plugin as PluginUtility;
+use IdeHelper\ValueObject\StringName;
+
+class SearchManagerAddFilterTask implements TaskInterface {
+
+	/**
+	 * @var list<string>
+	 */
+	protected array $defaultFilters = [
+		'Search.Boolean',
+		'Search.Callback',
+		'Search.Compare',
+		'Search.Exists',
+		'Search.Finder',
+		'Search.Like',
+		'Search.Value',
+	];
+
+	/**
+	 * @param bool $includeDefaultFilters Include built-in filters that are also available as fluent methods.
+	 */
+	public function __construct(
+		protected bool $includeDefaultFilters = true,
+	) {
+	}
+
+	/**
+	 * @return array<\IdeHelper\Generator\Directive\BaseDirective>
+	 */
+	public function collect(): array {
+		if (!Plugin::isLoaded('Search')) {
+			return [];
+		}
+
+		$method = '\Search\Manager::add()';
+
+		$list = [];
+		if ($this->includeDefaultFilters) {
+			foreach ($this->defaultFilters as $name) {
+				$list[$name] = StringName::create($name);
+			}
+		}
+
+		$filters = $this->collectFilters();
+		foreach ($filters as $name) {
+			$list[$name] = StringName::create($name);
+		}
+
+		ksort($list);
+
+		$directive = new ExpectedArguments($method, 1, $list);
+
+		return [$directive->key() => $directive];
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	protected function collectFilters(): array {
+		$filters = [];
+
+		$folders = AppPath::get('Model/Filter');
+		foreach ($folders as $folder) {
+			$filters = $this->addFilters($filters, $folder);
+		}
+
+		$plugins = PluginUtility::all();
+		foreach ($plugins as $plugin) {
+			$folders = AppPath::get('Model/Filter', $plugin);
+			foreach ($folders as $folder) {
+				$filters = $this->addFilters($filters, $folder, $plugin);
+			}
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * @param list<string> $filters
+	 * @param string $folder
+	 * @param string|null $plugin
+	 * @return list<string>
+	 */
+	protected function addFilters(array $filters, string $folder, ?string $plugin = null): array {
+		$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
+
+		foreach ($folderContent[1] as $file) {
+			preg_match('/^(.+)\.php$/', $file, $matches);
+			if (!$matches) {
+				continue;
+			}
+			$name = $matches[1];
+			if ($name === 'Base' || str_ends_with($name, 'Collection') || str_ends_with($name, 'Interface') || str_ends_with($name, 'Trait')) {
+				continue;
+			}
+
+			if ($plugin) {
+				$name = $plugin . '.' . $name;
+			}
+
+			$className = App::className($name, 'Model/Filter');
+			if (!$className) {
+				continue;
+			}
+
+			$filters[] = $name;
+		}
+
+		return $filters;
+	}
+
+}

--- a/tests/TestCase/Search/Generator/Task/SearchManagerAddFilterTaskTest.php
+++ b/tests/TestCase/Search/Generator/Task/SearchManagerAddFilterTaskTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IdeHelperExtra\Test\TestCase\Search\Generator\Task;
+
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use IdeHelperExtra\Search\Generator\Task\SearchManagerAddFilterTask;
+use Shim\TestSuite\TestTrait;
+
+class SearchManagerAddFilterTaskTest extends TestCase {
+
+	use TestTrait;
+
+	protected SearchManagerAddFilterTask $task;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->task = new SearchManagerAddFilterTask();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollect(): void {
+		if (!Plugin::isLoaded('Search')) {
+			$this->markTestSkipped('Search plugin not loaded');
+		}
+
+		$result = $this->task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+		$this->assertSame('\Search\Manager::add()', $directive->toArray()['method']);
+		$this->assertSame(1, $directive->toArray()['position']);
+
+		$list = $directive->toArray()['list'];
+
+		$list = array_map(function ($stringName) {
+			return (string)$stringName;
+		}, $list);
+
+		$this->assertArrayHasKey('Custom', $list);
+		$this->assertSame("'Custom'", $list['Custom']);
+
+		$this->assertArrayHasKey('Search.Value', $list);
+		$this->assertSame("'Search.Value'", $list['Search.Value']);
+
+		$this->assertArrayHasKey('Search.Like', $list);
+		$this->assertArrayHasKey('Search.Boolean', $list);
+		$this->assertArrayHasKey('Search.Callback', $list);
+		$this->assertArrayHasKey('Search.Compare', $list);
+		$this->assertArrayHasKey('Search.Exists', $list);
+		$this->assertArrayHasKey('Search.Finder', $list);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollectWithoutDefaultFilters(): void {
+		if (!Plugin::isLoaded('Search')) {
+			$this->markTestSkipped('Search plugin not loaded');
+		}
+
+		$task = new SearchManagerAddFilterTask(includeDefaultFilters: false);
+		$result = $task->collect();
+
+		$this->assertCount(1, $result);
+
+		/** @var \IdeHelper\Generator\Directive\ExpectedArguments $directive */
+		$directive = array_shift($result);
+
+		$list = $directive->toArray()['list'];
+
+		$list = array_map(function ($stringName) {
+			return (string)$stringName;
+		}, $list);
+
+		$this->assertArrayHasKey('Custom', $list);
+		$this->assertArrayNotHasKey('Search.Value', $list);
+		$this->assertArrayNotHasKey('Search.Like', $list);
+		$this->assertArrayNotHasKey('Search.Boolean', $list);
+		$this->assertArrayNotHasKey('Search.Callback', $list);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollectWithoutPlugin(): void {
+		if (Plugin::isLoaded('Search')) {
+			$this->markTestSkipped('Cannot test without Search plugin when it is loaded');
+		}
+
+		$result = $this->task->collect();
+
+		$this->assertEmpty($result);
+	}
+
+}

--- a/tests/test_app/src/Model/Filter/Custom.php
+++ b/tests/test_app/src/Model/Filter/Custom.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Model\Filter;
+
+/**
+ * Custom filter for testing.
+ */
+class Custom {
+
+}


### PR DESCRIPTION
## Summary

- Adds `SearchManagerAddFilterTask` for IDE autocomplete on the second parameter of `\Search\Manager::add()`
- Supports built-in Search plugin filters: `Value`, `Like`, `Boolean`, `Callback`, `Compare`, `Exists`, `Finder`
- Discovers custom filters from `App\Model\Filter\` and plugins
- Only activates when Search plugin is loaded

## Usage

Configure in your app's `config/app.php`:

```php
'IdeHelper' => [
    'generatorTasks' => [
        \IdeHelperExtra\Search\Generator\Task\SearchManagerAddFilterTask::class,
    ],
],
```

Then run:
```bash
bin/cake generate phpstorm
```

This enables autocomplete for filter types when using:
```php
$this->searchManager()
    ->add('status', 'Search.Callback', [ // ← autocomplete here
        'callback' => function ($query, $args, $filter) { ... }
    ]);
```

## Test plan

- [x] Tests pass (`composer test`)
- [x] Code style passes (`composer cs-check`)
- [x] PHPStan passes (`composer stan`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)