### PR TITLE
Add E_USER_DEPRECATED runtime signal to deprecated tasks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,10 @@ Supports IDE autocomplete/typehinting of (magic)strings as well as return types/
     * IconHelper::render() and FontAwesome v4/v5/v6 or Bootstrap icons [DEPRECATED] Now directly part of [Templating](https://github.com/dereuromark/cakephp-templating) plugin
 - [Authentication](https://github.com/cakephp/authentication) plugin
     * AuthenticationService::loadAuthenticator()
-    * IdentifierCollection::load()
+    * IdentifierCollection::load() [DEPRECATED] The upstream loadIdentifier() flow is going away in favor of passing identifiers directly to authenticators
 - ... and more (using PHPStorm meta file)
+
+The tasks marked as [DEPRECATED] still ship and emit an `E_USER_DEPRECATED` notice on construction. They will be removed in the next major release (3.0). Migrate now.
 
 See [IdeHelper Wiki](https://github.com/dereuromark/cakephp-ide-helper-extra/wiki) for details and tips/settings.
 

--- a/src/Authentication/Generator/Task/AuthServiceLoadIdentifierTask.php
+++ b/src/Authentication/Generator/Task/AuthServiceLoadIdentifierTask.php
@@ -17,6 +17,15 @@ use IdeHelper\ValueObject\ClassName;
  */
 class AuthServiceLoadIdentifierTask implements TaskInterface {
 
+	public function __construct() {
+		trigger_error(
+			'IdeHelperExtra AuthServiceLoadIdentifierTask is deprecated and will be removed in 3.0.'
+			. ' The Authentication plugin\'s loadIdentifier() flow is going away in favor of'
+			. ' passing identifiers directly to authenticators.',
+			E_USER_DEPRECATED,
+		);
+	}
+
 	/**
 	 * @return array<\IdeHelper\Generator\Directive\BaseDirective>
 	 */

--- a/src/Tools/Generator/Task/IconRenderTask.php
+++ b/src/Tools/Generator/Task/IconRenderTask.php
@@ -31,6 +31,12 @@ class IconRenderTask implements TaskInterface {
 	 * @param array|null $config
 	 */
 	public function __construct(?array $config = null) {
+		trigger_error(
+			'IdeHelperExtra IconRenderTask is deprecated and will be removed in 3.0.'
+			. ' Use the IconRenderTask shipped with dereuromark/cakephp-templating instead.',
+			E_USER_DEPRECATED,
+		);
+
 		if ($config === null) {
 			$config = Configure::read('Icon') ?: [];
 		}

--- a/tests/TestCase/Authentication/Generator/Task/AuthServiceLoadIdentifierTaskTest.php
+++ b/tests/TestCase/Authentication/Generator/Task/AuthServiceLoadIdentifierTaskTest.php
@@ -18,7 +18,7 @@ class AuthServiceLoadIdentifierTaskTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->task = new AuthServiceLoadIdentifierTask();
+		$this->task = @new AuthServiceLoadIdentifierTask();
 	}
 
 	/**

--- a/tests/TestCase/Tools/Generator/Task/IconRenderBootstrapTaskTest.php
+++ b/tests/TestCase/Tools/Generator/Task/IconRenderBootstrapTaskTest.php
@@ -50,7 +50,7 @@ class IconRenderBootstrapTaskTest extends TestCase {
 	 */
 	public function testCollect(): void {
 		$config = $this->helper->getConfig();
-		$task = new IconRenderTask($config);
+		$task = @new IconRenderTask($config);
 
 		$result = $task->collect();
 

--- a/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome4TaskTest.php
+++ b/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome4TaskTest.php
@@ -41,7 +41,7 @@ class IconRenderFontAwesome4TaskTest extends TestCase {
 	 */
 	public function testCollect(): void {
 		$config = $this->helper->getConfig();
-		$task = new IconRenderTask($config);
+		$task = @new IconRenderTask($config);
 
 		$result = $task->collect();
 

--- a/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome5TaskTest.php
+++ b/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome5TaskTest.php
@@ -42,7 +42,7 @@ class IconRenderFontAwesome5TaskTest extends TestCase {
 	public function testCollect(): void {
 		$config = $this->helper->getConfig();
 
-		$task = new IconRenderTask($config);
+		$task = @new IconRenderTask($config);
 
 		$result = $task->collect();
 

--- a/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome6TaskTest.php
+++ b/tests/TestCase/Tools/Generator/Task/IconRenderFontAwesome6TaskTest.php
@@ -42,7 +42,7 @@ class IconRenderFontAwesome6TaskTest extends TestCase {
 	public function testCollect(): void {
 		$config = $this->helper->getConfig();
 
-		$task = new IconRenderTask($config);
+		$task = @new IconRenderTask($config);
 
 		$result = $task->collect();
 


### PR DESCRIPTION
## Summary

- IconRenderTask and AuthServiceLoadIdentifierTask carried a class-level deprecation annotation but emitted no runtime signal and named no removal milestone, so consumers wiring them into IdeHelperConfig had nothing to migrate against.
- Both constructors now call `trigger_error(..., E_USER_DEPRECATED)` with a clear "removed in 3.0" message, and the readme bullet for `IdentifierCollection::load()` is marked `[DEPRECATED]` (matching the existing IconRenderTask bullet) plus a short note explaining the runtime notice and removal target.
- The four IconRender test classes and the AuthServiceLoadIdentifier test prepend the error-control operator to the expected deprecating instantiation so PHPUnit does not flag the now-emitted notice as a test failure.
